### PR TITLE
Auto-size note cards and single-column grouped list

### DIFF
--- a/frontend/anynote/lib/widgets/NoteList.dart
+++ b/frontend/anynote/lib/widgets/NoteList.dart
@@ -197,12 +197,8 @@ class _NoteItemWidgetState extends State<NoteItemWidget> {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        return Container(
-          constraints: widget.item.isTopMost
-              ? BoxConstraints(maxHeight: maxNoteItemHeight)
-              : BoxConstraints(
-                  maxHeight: maxNoteItemHeight - 50,
-                  minHeight: maxNoteItemHeight - 50),
+        return ConstrainedBox(
+          constraints: BoxConstraints(maxHeight: maxNoteItemHeight),
           child: Stack(
             children: [
               if (widget.item.isTopMost)
@@ -353,19 +349,72 @@ class _NoteItemWidgetState extends State<NoteItemWidget> {
 
 Widget BuildNoteList(List<NoteItem> archivedNotes, bool isArchive,
     {ScrollController? sc}) {
+  List<NoteItem> sortNotesByDateDesc(List<NoteItem> items) {
+    final sorted = List<NoteItem>.from(items);
+    sorted.sort((a, b) => b.createTime.compareTo(a.createTime));
+    return sorted;
+  }
+
+  DateTime normalizeDate(DateTime dateTime) {
+    return DateTime(dateTime.year, dateTime.month, dateTime.day);
+  }
+
+  List<_NoteListEntry> buildGroupedEntries(List<NoteItem> items) {
+    final entries = <_NoteListEntry>[];
+    if (items.isEmpty) {
+      return entries;
+    }
+
+    DateTime? currentDate;
+    final buffer = <NoteItem>[];
+
+    void flushGroup(DateTime dateKey, List<NoteItem> notes) {
+      entries.add(_NoteListEntry.header(
+          intl.DateFormat('yyyy-MM-dd').format(dateKey)));
+      for (final note in notes) {
+        entries.add(_NoteListEntry.item(note));
+      }
+    }
+
+    for (final note in items) {
+      final dateKey = normalizeDate(note.createTime);
+      if (currentDate == null || currentDate != dateKey) {
+        if (currentDate != null && buffer.isNotEmpty) {
+          flushGroup(currentDate, List<NoteItem>.from(buffer));
+          buffer.clear();
+        }
+        currentDate = dateKey;
+      }
+      buffer.add(note);
+    }
+
+    if (currentDate != null && buffer.isNotEmpty) {
+      flushGroup(currentDate, List<NoteItem>.from(buffer));
+    }
+
+    return entries;
+  }
+
   Widget buildHeader(String title) {
     return Padding(
-      padding: const EdgeInsets.only(left: 8, right: 8, top: 20, bottom: 10),
-      child: Row(
-        children: [
-          Text(
+      padding: const EdgeInsets.only(left: 8, right: 8, top: 16, bottom: 6),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: Colors.black12.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Text(
             title,
             style: const TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
-                color: Colors.black87),
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: Colors.black54,
+            ),
           ),
-        ],
+        ),
       ),
     );
   }
@@ -374,31 +423,18 @@ Widget BuildNoteList(List<NoteItem> archivedNotes, bool isArchive,
     final MainController controller = Get.find<MainController>();
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            timeAgo(item.createTime),
-            style: const TextStyle(fontSize: 10, color: Colors.black38),
-          ),
-          const SizedBox(height: 3),
-          NoteItemWidget(
-            key: ValueKey(item.id),
-            controller: controller,
-            item: item,
-            isArchive: isArchive,
-          ),
-        ],
+      child: NoteItemWidget(
+        key: ValueKey(item.id),
+        controller: controller,
+        item: item,
+        isArchive: isArchive,
       ),
     );
   }
 
   final topmostItems = archivedNotes.where((item) => item.isTopMost).toList();
   final normalItems = archivedNotes.where((item) => !item.isTopMost).toList();
-  final gridDelegate = SliverGridDelegateWithFixedCrossAxisCount(
-    crossAxisCount: 2,
-    mainAxisExtent: maxNoteItemHeight, // Use the maximum height defined
-  );
+  final groupedEntries = buildGroupedEntries(sortNotesByDateDesc(normalItems));
 
   return CustomScrollView(
     controller: sc,
@@ -412,16 +448,17 @@ Widget BuildNoteList(List<NoteItem> archivedNotes, bool isArchive,
           return buildItem(topmostItems[index]);
         },
       ),
-      if (normalItems.isNotEmpty)
-        SliverToBoxAdapter(
-          child: buildHeader("🗒️ Notes"),
-        ),
-      SliverGrid(
+      SliverList(
         delegate: SliverChildBuilderDelegate(
-          (context, index) => buildItem(normalItems[index]),
-          childCount: normalItems.length,
+          (context, index) {
+            final entry = groupedEntries[index];
+            if (entry.isHeader) {
+              return buildHeader(entry.title ?? "");
+            }
+            return buildItem(entry.item!);
+          },
+          childCount: groupedEntries.length,
         ),
-        gridDelegate: gridDelegate,
       ),
       const SliverToBoxAdapter(
           child: SizedBox(
@@ -431,18 +468,18 @@ Widget BuildNoteList(List<NoteItem> archivedNotes, bool isArchive,
   );
 }
 
-String timeAgo(DateTime dateTime) {
-  final Duration difference = DateTime.now().difference(dateTime);
+class _NoteListEntry {
+  final bool isHeader;
+  final String? title;
+  final NoteItem? item;
 
-  if (difference.inSeconds < 60) {
-    return '${difference.inSeconds} seconds ago';
-  } else if (difference.inMinutes < 60) {
-    return '${difference.inMinutes} minutes ago';
-  } else if (difference.inHours < 24) {
-    return '${difference.inHours} hours ago';
-  } else if (difference.inDays < 7) {
-    return '${difference.inDays} days ago';
-  } else {
-    return intl.DateFormat('yyyy-MM-dd HH:mm:ss').format(dateTime);
+  const _NoteListEntry._({required this.isHeader, this.title, this.item});
+
+  factory _NoteListEntry.header(String title) {
+    return _NoteListEntry._(isHeader: true, title: title);
+  }
+
+  factory _NoteListEntry.item(NoteItem item) {
+    return _NoteListEntry._(isHeader: false, item: item);
   }
 }


### PR DESCRIPTION
### Motivation
- Fix the issue where non-topmost notes were forced to a fixed minimum height so short notes occupied excessive vertical space.  
- Render notes grouped by date with clearer, subtler headers to improve readability.  
- Simplify layout to reduce redundant constraints and per-frame layout work for smoother scrolling.  

### Description
- Allow note cards to shrink to their content by constraining only the maximum height (`maxNoteItemHeight`) inside `NoteItemWidget` instead of enforcing a fixed `minHeight`.  
- Remove the extra per-item `ConstrainedBox` wrapper around `NoteItemWidget` so list items are not forcibly expanded.  
- Replace the two-column `SliverGrid` with a single-column `SliverList` and add `sortNotesByDateDesc`, `normalizeDate`, and `buildGroupedEntries` that produce `_NoteListEntry` entries to render date headers and items.  
- Restyle date headers in `buildHeader` to a pill-like appearance and remove the per-item `timeAgo` label to declutter item rows.  

### Testing
- No automated tests were run for this change.  
- No automated test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958cf9c1974832a859b45037adfb924)